### PR TITLE
Stack trace if package not in repos

### DIFF
--- a/upstream/client/lib/canvas/cli/commands/template.py
+++ b/upstream/client/lib/canvas/cli/commands/template.py
@@ -411,7 +411,11 @@ class TemplateCommand(Command):
         # process all packages in template
         for p in t.packages_all:
             if p.included():
-                db.install(p.to_pkg_spec())
+                try:
+                    db.install(p.to_pkg_spec())
+                except:
+                    print ("error: Package does not exist " + str(p))
+                    pass
 
             else:
                 db.remove(p.to_pkg_spec())
@@ -457,7 +461,9 @@ class TemplateCommand(Command):
         print('info: syncing history ...')
         for p in t.packages_all:
             if p.included():
-                db.yumdb.get_package(p.to_pkg()).reason = 'user'
+                pkg = p.to_pkg();
+                if pkg is not None:
+                    db.yumdb.get_package(pkg).reason = 'user'
 
     def run_push(self):
         t = Template(self.args.template, user=self.args.username)

--- a/upstream/client/lib/canvas/package.py
+++ b/upstream/client/lib/canvas/package.py
@@ -94,10 +94,10 @@ class Package(object):
     def __ne__(self, other):
         return (not self.__eq__(other))
 
-    def __repr__(self):
+    def __str__(self):
         return 'Package: %s' % (self.to_pkg_spec())
 
-    def __str__(self):
+    def __repr__(self):
         return 'Package: %s' % (json.dumps(self.to_object(), separators=(',', ':')))
 
     def excluded(self):

--- a/upstream/client/lib/canvas/package.py
+++ b/upstream/client/lib/canvas/package.py
@@ -208,6 +208,9 @@ class Package(object):
 
         p_list = db.sack.query().installed().filter(name=self.name)
 
+        if not p_list:
+            return None
+
         return list(p_list)[0]
 
 


### PR DESCRIPTION
If a package that is not present in the current repos is added to a template we get the following stack trace.

Traceback (most recent call last):
  File "./canvas", line 81, in <module>
    sys.exit(cli.run())
  File "./lib/canvas/cli/commands/template.py", line 131, in run
    return command()
  File "./lib/canvas/cli/commands/template.py", line 414, in run_pull
    db.install(p.to_pkg_spec())
  File "/usr/lib/python3.4/site-packages/dnf/base.py", line 1433, in install
    _('no package matched'), pkg_spec)
dnf.exceptions.MarkingError: no package matched

The below commits will catch this and print a warning.
